### PR TITLE
Add working hours configuration and hourly deficit tracking

### DIFF
--- a/content.js
+++ b/content.js
@@ -74,6 +74,8 @@ function checkTable(table, cfg) {
   today.setHours(0,0,0,0);
 
   const missingDays = [];
+  let todayFound = false;
+  let todayHours = 0;
   perDayCells.forEach((td, i) => {
     const ymd = theadDates[i];
     const d = parseYMD(ymd);
@@ -84,6 +86,11 @@ function checkTable(table, cfg) {
 
     const txt = (td.textContent || "").replace(/\s+/g, "").replace(",", ".").trim(); // например "8.00"
     const hours = txt ? parseFloat(txt) : 0;
+
+    if (sameDay(d, today)) {
+      todayFound = true;
+      todayHours = isFinite(hours) ? hours : 0;
+    }
 
     const ok = hours >= cfg.minHoursPerDay; // допускаем >= 8.00
     if (!ok) {
@@ -98,6 +105,6 @@ function checkTable(table, cfg) {
     }
   });
 
-  return { missingDays };
+  return { missingDays, hoursToday: todayFound ? todayHours : 0, todayFound };
 }
 

--- a/options.html
+++ b/options.html
@@ -11,6 +11,8 @@
     button { padding:8px 12px; margin-right:8px; }
     small { color:#666; }
     code { background:#f3f3f3; padding:1px 4px; }
+    .weekdays { display:flex; flex-wrap:wrap; gap:8px; margin:4px 0 8px; }
+    .weekdays label { display:flex; align-items:center; gap:4px; font-weight:400; margin:0; }
   </style>
 </head>
 <body>
@@ -27,9 +29,32 @@
       <label><input id="highlight" type="checkbox" /> Подсвечивать ячейки на странице</label>
     </div>
     <div>
-      <label>Время проверок (локальное), через запятую</label>
-      <input id="times" type="text" />
-      <small>Формат: <code>08:00,17:00,18:00,19:00</code>. Изменение перезапускает ежедневные задачи.</small>
+      <label>Рабочие часы</label>
+      <div class="row">
+        <div>
+          <label for="workStart">Начало</label>
+          <input id="workStart" type="time" />
+        </div>
+        <div>
+          <label for="workEnd">Конец</label>
+          <input id="workEnd" type="time" />
+        </div>
+      </div>
+      <label for="lunchStart">Начало обеда</label>
+      <input id="lunchStart" type="time" />
+      <label for="lunchDurationMinutes">Длительность обеда (минут)</label>
+      <input id="lunchDurationMinutes" type="number" step="5" min="0" />
+      <label>Рабочие дни</label>
+      <div class="weekdays">
+        <label><input type="checkbox" name="workingDays" value="1" /> Пн</label>
+        <label><input type="checkbox" name="workingDays" value="2" /> Вт</label>
+        <label><input type="checkbox" name="workingDays" value="3" /> Ср</label>
+        <label><input type="checkbox" name="workingDays" value="4" /> Чт</label>
+        <label><input type="checkbox" name="workingDays" value="5" /> Пт</label>
+        <label><input type="checkbox" name="workingDays" value="6" /> Сб</label>
+        <label><input type="checkbox" name="workingDays" value="0" /> Вс</label>
+      </div>
+      <small>Скрипт запускается каждый час только в отмеченные рабочие дни и вне обеденного перерыва.</small>
     </div>
   </div>
 

--- a/options.js
+++ b/options.js
@@ -1,9 +1,13 @@
 const DEFAULTS = {
   reportUrl: "https://max.rm.mosreg.ru/time_entries/report?utf8=%E2%9C%93&criteria%5B%5D=user&columns=day&criteria%5B%5D=&set_filter=1&type=TimeEntryQuery&f%5B%5D=spent_on&op%5Bspent_on%5D=%3E%3Ct-&v%5Bspent_on%5D%5B%5D=14&f%5B%5D=user_id&op%5Buser_id%5D=%3D&v%5Buser_id%5D%5B%5D=me&query%5Bsort_criteria%5D%5B0%5D%5B%5D=spent_on&query%5Bsort_criteria%5D%5B0%5D%5B%5D=desc&query%5Bgroup_by%5D=spent_on&t%5B%5D=hours&c%5B%5D=project&c%5B%5D=spent_on&c%5B%5D=user&c%5B%5D=activity&c%5B%5D=issue&c%5B%5D=comments&c%5B%5D=hours&saved_query_id=0",
   minHoursPerDay: 8,
-  excludeToday: true,
+  excludeToday: false,
   highlight: true,
-  times: ["08:00", "17:00", "18:00", "19:00"]
+  workStart: "09:00",
+  workEnd: "18:00",
+  lunchStart: "13:00",
+  lunchDurationMinutes: 60,
+  workingDays: [1, 2, 3, 4, 5]
 };
 
 const els = {
@@ -11,7 +15,11 @@ const els = {
   minHoursPerDay: document.getElementById("minHoursPerDay"),
   excludeToday: document.getElementById("excludeToday"),
   highlight: document.getElementById("highlight"),
-  times: document.getElementById("times"),
+  workStart: document.getElementById("workStart"),
+  workEnd: document.getElementById("workEnd"),
+  lunchStart: document.getElementById("lunchStart"),
+  lunchDurationMinutes: document.getElementById("lunchDurationMinutes"),
+  workingDays: Array.from(document.querySelectorAll("input[name='workingDays']")),
   save: document.getElementById("save"),
   reset: document.getElementById("reset")
 };
@@ -22,16 +30,32 @@ async function load() {
   els.minHoursPerDay.value = cfg.minHoursPerDay;
   els.excludeToday.checked = cfg.excludeToday;
   els.highlight.checked = cfg.highlight;
-  els.times.value = (cfg.times || DEFAULTS.times).join(",");
+  els.workStart.value = cfg.workStart || DEFAULTS.workStart;
+  els.workEnd.value = cfg.workEnd || DEFAULTS.workEnd;
+  els.lunchStart.value = cfg.lunchStart || DEFAULTS.lunchStart;
+  els.lunchDurationMinutes.value = cfg.lunchDurationMinutes ?? DEFAULTS.lunchDurationMinutes;
+  const selectedDays = Array.isArray(cfg.workingDays) && cfg.workingDays.length
+    ? cfg.workingDays.map(Number)
+    : DEFAULTS.workingDays;
+  els.workingDays.forEach(cb => {
+    cb.checked = selectedDays.includes(Number(cb.value));
+  });
 }
 async function save() {
-  const times = els.times.value.split(",").map(s => s.trim()).filter(Boolean);
+  const workingDays = els.workingDays.filter(cb => cb.checked).map(cb => Number(cb.value));
+  const sanitizeTime = (value, fallback) => {
+    return value && /^([0-1]?\d|2[0-3]):([0-5]\d)$/.test(value) ? value : fallback;
+  };
   await chrome.storage.sync.set({
     reportUrl: els.reportUrl.value.trim(),
     minHoursPerDay: Number(els.minHoursPerDay.value),
     excludeToday: !!els.excludeToday.checked,
     highlight: !!els.highlight.checked,
-    times
+    workStart: sanitizeTime(els.workStart.value, DEFAULTS.workStart),
+    workEnd: sanitizeTime(els.workEnd.value, DEFAULTS.workEnd),
+    lunchStart: sanitizeTime(els.lunchStart.value, DEFAULTS.lunchStart),
+    lunchDurationMinutes: Number(els.lunchDurationMinutes.value) || 0,
+    workingDays: workingDays.length ? workingDays : DEFAULTS.workingDays
   });
   // Пересоздаём алармы
   chrome.runtime.getBackgroundPage


### PR DESCRIPTION
## Summary
- add working-hours, lunch break, and working-day configuration to the background scheduler
- compute hourly expected time, show the deficit as a badge, and keep existing notifications for past missing days
- expose the new scheduling controls on the options page and persist them in synced storage

## Testing
- not run (extension changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4ca83ea948329b3a104f514a479e9