### PR TITLE
Remove skip-today option and check previous weekdays

### DIFF
--- a/options.html
+++ b/options.html
@@ -25,7 +25,6 @@
     <div>
       <label>Минимум часов в день</label>
       <input id="minHoursPerDay" type="number" step="0.25" min="0" />
-      <label><input id="excludeToday" type="checkbox" /> Не проверять сегодняшний день</label>
       <label><input id="highlight" type="checkbox" /> Подсвечивать ячейки на странице</label>
     </div>
     <div>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,6 @@
 const DEFAULTS = {
   reportUrl: "https://max.rm.mosreg.ru/time_entries/report?utf8=%E2%9C%93&criteria%5B%5D=user&columns=day&criteria%5B%5D=&set_filter=1&type=TimeEntryQuery&f%5B%5D=spent_on&op%5Bspent_on%5D=%3E%3Ct-&v%5Bspent_on%5D%5B%5D=14&f%5B%5D=user_id&op%5Buser_id%5D=%3D&v%5Buser_id%5D%5B%5D=me&query%5Bsort_criteria%5D%5B0%5D%5B%5D=spent_on&query%5Bsort_criteria%5D%5B0%5D%5B%5D=desc&query%5Bgroup_by%5D=spent_on&t%5B%5D=hours&c%5B%5D=project&c%5B%5D=spent_on&c%5B%5D=user&c%5B%5D=activity&c%5B%5D=issue&c%5B%5D=comments&c%5B%5D=hours&saved_query_id=0",
   minHoursPerDay: 8,
-  excludeToday: false,
   highlight: true,
   workStart: "09:00",
   workEnd: "18:00",
@@ -13,7 +12,6 @@ const DEFAULTS = {
 const els = {
   reportUrl: document.getElementById("reportUrl"),
   minHoursPerDay: document.getElementById("minHoursPerDay"),
-  excludeToday: document.getElementById("excludeToday"),
   highlight: document.getElementById("highlight"),
   workStart: document.getElementById("workStart"),
   workEnd: document.getElementById("workEnd"),
@@ -28,7 +26,6 @@ async function load() {
   const cfg = await chrome.storage.sync.get(DEFAULTS);
   els.reportUrl.value = cfg.reportUrl;
   els.minHoursPerDay.value = cfg.minHoursPerDay;
-  els.excludeToday.checked = cfg.excludeToday;
   els.highlight.checked = cfg.highlight;
   els.workStart.value = cfg.workStart || DEFAULTS.workStart;
   els.workEnd.value = cfg.workEnd || DEFAULTS.workEnd;
@@ -49,7 +46,6 @@ async function save() {
   await chrome.storage.sync.set({
     reportUrl: els.reportUrl.value.trim(),
     minHoursPerDay: Number(els.minHoursPerDay.value),
-    excludeToday: !!els.excludeToday.checked,
     highlight: !!els.highlight.checked,
     workStart: sanitizeTime(els.workStart.value, DEFAULTS.workStart),
     workEnd: sanitizeTime(els.workEnd.value, DEFAULTS.workEnd),


### PR DESCRIPTION
## Summary
- remove the "Не проверять сегодняшний день" option from the settings UI and stored defaults
- always parse the current day for badge calculations while collecting deficits only for previous weekdays
- keep highlighting of relevant cells when enabled and notify about past shortages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4e6af9ce48329af0ce6fc74d6eba2