### PR TITLE
Handle report errors as zero logged hours

### DIFF
--- a/background.js
+++ b/background.js
@@ -78,13 +78,12 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
 async function handleResultMessage(payload, sender) {
   const settings = await getSettings();
 
-  if (payload.error) {
+  const hasError = Boolean(payload?.error);
+  if (hasError) {
     notify("Не удалось проверить отчёт", payload.error);
-    closeTechnicalTab(sender);
-    return;
   }
 
-  const missingDays = Array.isArray(payload.missingDays) ? payload.missingDays : [];
+  const missingDays = !hasError && Array.isArray(payload.missingDays) ? payload.missingDays : [];
   if (missingDays.length > 0) {
     const lines = missingDays
       .map(d => `${d.date}: ${d.hours.toFixed(2)} ч`)
@@ -95,7 +94,7 @@ async function handleResultMessage(payload, sender) {
   const checkedAt = payload.checkedAt ? new Date(payload.checkedAt) : new Date();
   const isWorkDay = isWorkingDay(checkedAt, settings.workingDays);
   const expectedHours = isWorkDay ? calculateExpectedHours(checkedAt, settings) : 0;
-  const loggedHours = typeof payload.hoursToday === "number" && isFinite(payload.hoursToday)
+  const loggedHours = !hasError && typeof payload.hoursToday === "number" && isFinite(payload.hoursToday)
     ? payload.hoursToday
     : 0;
   const deficit = Math.max(0, expectedHours - loggedHours);

--- a/content.js
+++ b/content.js
@@ -5,7 +5,7 @@
   });
 
   try {
-    const table = await waitForTable("#time-report", 20000); // до 20 секунд
+    const table = await waitForTable("#time-report", 10000); // до 10 секунд
     const result = checkTable(table, cfg);
     chrome.runtime.sendMessage({ type: "RM8H_RESULT", payload: { ...result, url: location.href, checkedAt: new Date().toISOString() } });
   } catch (e) {


### PR DESCRIPTION
## Summary
- treat report retrieval errors as a zero-hour day while still showing the failure notification
- avoid checking historical deficits when the report is unavailable and continue closing the tab
- reduce the waitForTable timeout to 10 seconds

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e61d3dfafc8329b16b795ccf23e6d0