### PR TITLE
Handle parser failures as default results

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,7 +9,18 @@
     const result = checkTable(table, cfg);
     chrome.runtime.sendMessage({ type: "RM8H_RESULT", payload: { ...result, url: location.href, checkedAt: new Date().toISOString() } });
   } catch (e) {
-    chrome.runtime.sendMessage({ type: "RM8H_RESULT", payload: { error: String(e && e.message || e) } });
+    const message = e && e.message ? e.message : String(e);
+    chrome.runtime.sendMessage({
+      type: "RM8H_RESULT",
+      payload: {
+        missingDays: [],
+        hoursToday: 0,
+        todayFound: false,
+        error: message,
+        url: location.href,
+        checkedAt: new Date().toISOString()
+      }
+    });
   }
 })();
 


### PR DESCRIPTION
## Summary
- send RM8H_RESULT with default hours and no missing days when the report table cannot be parsed
- keep error details in the payload so the background script can display a notification

## Testing
- not run (extension scripts, no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e772e515408329af52dc90a4d71ef5