### PR TITLE
Add extensive logging to background and content scripts

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,10 @@
+// Универсальная функция логирования с единым префиксом
+function log(...args) {
+  console.log("[RM8H][background]", ...args);
+}
+
+log("Background script initialized");
+
 // Базовый URL готового отчёта в Redmine, который открываем при проверке
 const DEFAULT_REPORT_URL =
   "https://max.rm.mosreg.ru/time_entries/report?utf8=%E2%9C%93&criteria%5B%5D=user&columns=day&criteria%5B%5D=&set_filter=1&type=TimeEntryQuery&f%5B%5D=spent_on&op%5Bspent_on%5D=%3E%3Ct-&v%5Bspent_on%5D%5B%5D=14&f%5B%5D=user_id&op%5Buser_id%5D=%3D&v%5Buser_id%5D%5B%5D=me&query%5Bsort_criteria%5D%5B0%5D%5B%5D=spent_on&query%5Bsort_criteria%5D%5B0%5D%5B%5D=desc&query%5Bgroup_by%5D=spent_on&t%5B%5D=hours&c%5B%5D=project&c%5B%5D=spent_on&c%5B%5D=user&c%5B%5D=activity&c%5B%5D=issue&c%5B%5D=comments&c%5B%5D=hours&saved_query_id=0";
@@ -13,21 +20,35 @@ const DEFAULT_SETTINGS = {
 };
 
 // При установке и запуске расширения пересоздаём расписание проверок
-chrome.runtime.onInstalled.addListener(() => initSchedules());
-chrome.runtime.onStartup.addListener(() => initSchedules());
+chrome.runtime.onInstalled.addListener(() => {
+  log("onInstalled event received – reinitializing schedules");
+  initSchedules();
+});
+chrome.runtime.onStartup.addListener(() => {
+  log("onStartup event received – reinitializing schedules");
+  initSchedules();
+});
 
 // Клик по иконке — принудительная проверка (всегда открываем отчёт в фоне)
-chrome.action.onClicked.addListener(() => triggerCheck("manual"));
+chrome.action.onClicked.addListener(() => {
+  log("Browser action clicked – triggering manual check");
+  triggerCheck("manual");
+});
 
 // Реакция на срабатывание любого аларма расширения
 chrome.alarms.onAlarm.addListener(alarm => {
+  log("Alarm fired", alarm);
   // Игнорируем сторонние алармы, обрабатываем только свои
-  if (!alarm.name.startsWith("rm8h:")) return;
+  if (!alarm.name.startsWith("rm8h:")) {
+    log("Ignoring alarm without rm8h prefix", alarm?.name);
+    return;
+  }
   // Запускаем автоматическую проверку
   triggerCheck("scheduled");
 });
 
 function notify(title, message) {
+  log("Creating notification", { title, message });
   // Создаём системное уведомление с заданными параметрами
   chrome.notifications.create({
     type: "basic",
@@ -39,19 +60,27 @@ function notify(title, message) {
 }
 
 async function initSchedules() {
+  log("Initializing schedules");
   // Получаем актуальные настройки пользователя
   const settings = await getSettings();
+  log("Fetched settings for schedule initialization", settings);
 
   // Сначала очищаем старые алармы, чтобы не было дубликатов расписания
   const alarms = await chrome.alarms.getAll();
-  await Promise.all(alarms.filter(a => a.name.startsWith("rm8h:")).map(a => chrome.alarms.clear(a.name)));
+  log("Existing alarms", alarms);
+  const ownAlarms = alarms.filter(a => a.name.startsWith("rm8h:"));
+  log("Alarms to clear", ownAlarms);
+  await Promise.all(ownAlarms.map(a => chrome.alarms.clear(a.name)));
+  log("Cleared old alarms");
 
   // Генерируем список времени для проверок и создаём алармы на каждый слот
   const times = buildCheckTimes(settings);
+  log("Generated check times", times);
   times.forEach(t => scheduleDailyAlarm(`rm8h:${t}`, t));
 }
 
 function scheduleDailyAlarm(name, hhmm) {
+  log("Scheduling daily alarm", { name, hhmm });
   // Разбираем строку времени в часы и минуты
   const [h, m] = hhmm.split(":").map(Number);
   const now = new Date();
@@ -61,75 +90,106 @@ function scheduleDailyAlarm(name, hhmm) {
   // Если время уже прошло сегодня, переносим на следующий день
   if (next <= now) next.setDate(next.getDate() + 1);
   // Создаём ежедневный аларм с периодом в сутки
+  const when = next.getTime();
+  log("Creating alarm", { name, when, humanTime: new Date(when).toISOString() });
   chrome.alarms.create(name, {
-    when: next.getTime(),
+    when,
     periodInMinutes: 1440
   });
 }
 
 async function triggerCheck(source) {
+  log("Trigger check invoked", { source });
   // Берём текущие настройки и время
   const settings = await getSettings();
+  log("Settings for trigger check", settings);
   const now = new Date();
+  log("Current time", now.toISOString());
 
   if (source !== "manual") {
     // Для автоматических запусков проверяем, что сегодня рабочий день
-    if (!isWorkingDay(now, settings.workingDays)) return;
+    const workingDay = isWorkingDay(now, settings.workingDays);
+    log("Is working day?", workingDay);
+    if (!workingDay) {
+      log("Aborting scheduled check: not a working day");
+      return;
+    }
     // ...и что сейчас рабочее время (не обед и не вне смены)
-    if (!isWithinWorkingWindow(now, settings)) return;
+    const withinWindow = isWithinWorkingWindow(now, settings);
+    log("Within working window?", withinWindow);
+    if (!withinWindow) {
+      log("Aborting scheduled check: outside working window");
+      return;
+    }
   }
 
   const reportUrl = settings.reportUrl || DEFAULT_REPORT_URL;
+  log("Opening report tab", reportUrl);
   // Открываем вкладку с отчётом в фоне — контент-скрипт продолжит работу
   chrome.tabs.create({ url: reportUrl, active: false });
 }
 
 chrome.runtime.onMessage.addListener((msg, sender) => {
+  log("Message received", { msg, sender });
   if (msg?.type === "RM8H_RESULT") {
     // Контент-скрипт прислал результат проверки — обрабатываем
     handleResultMessage(msg.payload || {}, sender);
   } else if (msg?.type === "RM8H_RESCHEDULE") {
     // Опции изменились, пересобираем расписание проверок
+    log("Reschedule message received – reinitializing schedules");
     initSchedules();
   }
 });
 
 async function handleResultMessage(payload, sender) {
+  log("Handling result message", { payload, sender });
   // Берём настройки, чтобы знать рабочие дни и нормы
   const settings = await getSettings();
+  log("Settings while handling result", settings);
 
   const hasError = Boolean(payload?.error);
+  log("Result contains error?", hasError);
   if (hasError) {
     // Если контент-скрипт сообщил об ошибке, показываем уведомление
+    log("Sending error notification", payload.error);
     notify("Не удалось проверить отчёт", payload.error);
   }
 
   const missingDays = !hasError && Array.isArray(payload.missingDays) ? payload.missingDays : [];
+  log("Missing days list", missingDays);
   if (missingDays.length > 0) {
     // Если есть дни с недобором часов, выводим список в уведомлении
     const lines = missingDays
       .map(d => `${d.date}: ${d.hours.toFixed(2)} ч`)
       .join("\n");
+    log("Sending missing days notification", lines);
     notify("Недобор часов по будням", lines);
   }
 
   // Определяем дату проверки и ожидаемое количество часов к текущему моменту
   const checkedAt = payload.checkedAt ? new Date(payload.checkedAt) : new Date();
+  log("Checked at", checkedAt.toISOString());
   const isWorkDay = isWorkingDay(checkedAt, settings.workingDays);
+  log("Is checked day working day?", isWorkDay);
   const expectedHours = isWorkDay ? calculateExpectedHours(checkedAt, settings) : 0;
+  log("Expected hours for day", expectedHours);
   // Фактически заполненное количество часов за сегодня
   const loggedHours = !hasError && typeof payload.hoursToday === "number" && isFinite(payload.hoursToday)
     ? payload.hoursToday
     : 0;
+  log("Logged hours for today", loggedHours);
   const deficit = Math.max(0, expectedHours - loggedHours);
   const badgeValue = Math.max(0, Math.ceil(deficit - 1e-9));
+  log("Calculated deficit and badge value", { deficit, badgeValue });
 
   if (badgeValue > 0) {
     // Если есть недобор, подсвечиваем и ставим значение на бейдже иконки
+    log("Setting badge for deficit", badgeValue);
     chrome.action.setBadgeBackgroundColor({ color: "#d00" });
     chrome.action.setBadgeText({ text: String(badgeValue) });
   } else {
     // В противном случае очищаем бейдж
+    log("Clearing badge – no deficit");
     chrome.action.setBadgeText({ text: "" });
   }
 
@@ -138,11 +198,14 @@ async function handleResultMessage(payload, sender) {
 }
 
 async function getSettings() {
+  log("Fetching settings from storage");
   // Забираем настройки из синхронизированного хранилища и подмешиваем значения по умолчанию
   const stored = await chrome.storage.sync.get(DEFAULT_SETTINGS);
+  log("Raw stored settings", stored);
   const workingDays = Array.isArray(stored.workingDays) && stored.workingDays.length
     ? stored.workingDays.map(Number)
     : DEFAULT_SETTINGS.workingDays;
+  log("Normalized working days", workingDays);
   return {
     ...DEFAULT_SETTINGS,
     ...stored,
@@ -151,16 +214,21 @@ async function getSettings() {
 }
 
 function isWorkingDay(date, workingDays) {
+  log("Checking if date is working day", { date: date.toISOString(), workingDays });
   // Получаем номер дня недели и проверяем, есть ли он в списке рабочих
   const day = date.getDay();
+  log("Day index", day);
   return workingDays.includes(day);
 }
 
 function isWithinWorkingWindow(date, settings) {
+  log("Checking if within working window", { date: date.toISOString(), settings });
   // Переводим текущее время в минуты с начала суток
   const minutes = date.getHours() * 60 + date.getMinutes();
+  log("Minutes since start of day", minutes);
   const start = parseTime(settings.workStart);
   const end = parseTime(settings.workEnd);
+  log("Parsed start/end", { start, end });
   // Если границы не заданы — считаем, что работать можно всегда
   if (start == null || end == null) return true;
   // Если текущее время вне диапазона — завершить проверку
@@ -171,79 +239,116 @@ function isWithinWorkingWindow(date, settings) {
     ? lunchStart + (Number(settings.lunchDurationMinutes) || 0)
     : null;
 
+  log("Lunch window", { lunchStart, lunchEnd });
+
   // Исключаем из рабочего окна период обеда
   if (lunchStart != null && lunchEnd != null && minutes >= lunchStart && minutes < lunchEnd) {
+    log("Time falls into lunch window");
     return false;
   }
+  log("Time within working window");
   return true;
 }
 
 function calculateExpectedHours(date, settings) {
+  log("Calculating expected hours", { date: date.toISOString(), settings });
   // Подсчитываем, сколько часовых слотов уже завершилось к текущему времени
   const minutes = date.getHours() * 60 + date.getMinutes();
+  log("Minutes for expected hours", minutes);
   const slots = buildWorkingHourSlots(settings);
+  log("Slots for expected hours", slots);
   if (!slots.length) return 0;
   const completed = slots.filter(min => minutes >= min).length;
+  log("Completed slots count", completed);
   return Math.min(completed, slots.length);
 }
 
 function buildWorkingHourSlots(settings) {
+  log("Building working hour slots", settings);
   // Строим массив стартов рабочих часов с учётом обеда
   const start = parseTime(settings.workStart);
   const end = parseTime(settings.workEnd);
+  log("Parsed start/end for slots", { start, end });
   if (start == null || end == null || end <= start) return [];
 
   const lunchStart = parseTime(settings.lunchStart);
   const lunchDuration = Number(settings.lunchDurationMinutes) || 0;
   const lunchEnd = lunchStart != null ? lunchStart + lunchDuration : null;
 
+  log("Lunch configuration", { lunchStart, lunchEnd, lunchDuration });
+
   const slots = [];
   for (let t = start; t < end; t += 60) {
     // Пропускаем часы, приходящиеся на обеденный перерыв
-    if (lunchStart != null && lunchEnd != null && t >= lunchStart && t < lunchEnd) continue;
+    if (lunchStart != null && lunchEnd != null && t >= lunchStart && t < lunchEnd) {
+      log("Skipping slot due to lunch", t);
+      continue;
+    }
+    log("Adding slot", t);
     slots.push(t);
   }
+  log("Final slots list", slots);
   return slots;
 }
 
 function buildCheckTimes(settings) {
+  log("Building check times", settings);
   // Переводим минутные отметки в формат "HH:MM" для создания алармов
   const slots = buildWorkingHourSlots(settings);
+  log("Slots for check times", slots);
   const times = slots.map(minutesToTime);
+  log("Converted time strings", times);
   const end = parseTime(settings.workEnd);
   const start = parseTime(settings.workStart);
+  log("Parsed start/end for check times", { start, end });
   if (end != null && start != null && end > start) {
     const endStr = minutesToTime(end);
     if (!times.includes(endStr)) times.push(endStr);
   }
+  log("Final check times", times);
   return times;
 }
 
 function parseTime(str) {
+  log("Parsing time string", str);
   // Валидируем и преобразуем строку времени в количество минут
   if (typeof str !== "string") return null;
   const match = str.trim().match(/^([0-1]?\d|2[0-3]):([0-5]\d)$/);
+  log("Time parse regex result", match);
   if (!match) return null;
   return Number(match[1]) * 60 + Number(match[2]);
 }
 
 function minutesToTime(min) {
+  log("Converting minutes to HH:MM", min);
   // Форматируем минуты в строку вида "HH:MM"
   const hh = String(Math.floor(min / 60)).padStart(2, "0");
   const mm = String(min % 60).padStart(2, "0");
+  log("Formatted parts", { hh, mm });
   return `${hh}:${mm}`;
 }
 
 function closeTechnicalTab(sender) {
+  log("Checking whether to close technical tab", sender);
   // Проверяем, что сообщение пришло с вкладки Redmine
   if (!sender?.tab?.id) return;
   const tabUrl = sender.tab.pendingUrl || sender.tab.url || "";
+  log("Sender tab URL", tabUrl);
   if (!tabUrl.startsWith("https://max.rm.mosreg.ru")) return;
 
   // Если вкладка неактивна, закрываем её, чтобы не мешать пользователю
   chrome.tabs.get(sender.tab.id, t => {
-    if (chrome.runtime.lastError) return;
-    if (!t.active) chrome.tabs.remove(sender.tab.id);
+    if (chrome.runtime.lastError) {
+      log("Error fetching tab", chrome.runtime.lastError);
+      return;
+    }
+    log("Tab info", t);
+    if (!t.active) {
+      log("Closing inactive technical tab", sender.tab.id);
+      chrome.tabs.remove(sender.tab.id);
+    } else {
+      log("Keeping active tab open", sender.tab.id);
+    }
   });
 }
 

--- a/content.js
+++ b/content.js
@@ -1,20 +1,36 @@
+function log(...args) {
+  console.log("[RM8H][content]", ...args);
+}
+
+log("Content script injected", { url: location.href, injectedAt: new Date().toISOString() });
+
 (async function main() {
+  log("Main routine started");
   // Считываем настройки подсчёта часов из синхронизированного хранилища
   const cfg = await chrome.storage.sync.get({
     minHoursPerDay: 8,             // минимум часов
     highlight: true                // подсветить проблемные ячейки на странице
   });
+  log("Fetched content settings", cfg);
 
   try {
     // Ждём появления таблицы отчёта (до 10 секунд)
-    const table = await waitForTable("#time-report", 10000);
+    const selector = "#time-report";
+    const timeoutMs = 10000;
+    log("Waiting for report table", { selector, timeoutMs });
+    const table = await waitForTable(selector, timeoutMs);
+    log("Report table acquired", { selector, found: Boolean(table) });
     // Анализируем таблицу и собираем данные о часах
     const result = checkTable(table, cfg);
+    log("Table processed", result);
     // Отправляем фоновой части результат проверки
-    chrome.runtime.sendMessage({ type: "RM8H_RESULT", payload: { ...result, url: location.href, checkedAt: new Date().toISOString() } });
+    const payload = { ...result, url: location.href, checkedAt: new Date().toISOString() };
+    log("Sending success payload", payload);
+    chrome.runtime.sendMessage({ type: "RM8H_RESULT", payload });
   } catch (e) {
     // В случае ошибки формируем сообщение и уведомляем фон
     const message = e && e.message ? e.message : String(e);
+    log("Error during table handling", { error: e, message });
     chrome.runtime.sendMessage({
       type: "RM8H_RESULT",
       payload: {
@@ -26,28 +42,36 @@
         checkedAt: new Date().toISOString()
       }
     });
+    log("Error payload sent", { message });
   }
 })();
 
 function waitForTable(sel, timeoutMs) {
+  log("waitForTable invoked", { sel, timeoutMs });
   // Возвращаем промис, который резолвится, когда нужная таблица появится в DOM
   return new Promise((resolve, reject) => {
     const el = document.querySelector(sel);
     // Если уже есть — возвращаем сразу
-    if (el) return resolve(el);
+    if (el) {
+      log("Table already present", { sel });
+      return resolve(el);
+    }
 
     // Подписываемся на изменения DOM и ждём таблицу
     const obs = new MutationObserver(() => {
       const t = document.querySelector(sel);
       if (t) {
+        log("MutationObserver detected table", { sel });
         obs.disconnect();
         resolve(t);
       }
     });
     obs.observe(document.documentElement, { childList: true, subtree: true });
+    log("MutationObserver attached", { sel });
 
     // Ставим таймер, после которого считаем, что таблицы нет
     const to = setTimeout(() => {
+      log("waitForTable timeout elapsed", { sel, timeoutMs });
       obs.disconnect();
       reject(new Error("Таблица отчёта не найдена"));
     }, timeoutMs);
@@ -56,6 +80,7 @@ function waitForTable(sel, timeoutMs) {
     window.addEventListener("load", () => {
       const t = document.querySelector(sel);
       if (t) {
+        log("Window load handler located table", { sel });
         clearTimeout(to);
         obs.disconnect();
         resolve(t);
@@ -65,34 +90,52 @@ function waitForTable(sel, timeoutMs) {
 }
 
 function parseYMD(ymd) {
+  log("parseYMD called", { ymd });
   // "YYYY-MM-DD" → Date (локальная полночь)
   const [Y, M, D] = ymd.split("-").map(Number);
-  return new Date(Y, M - 1, D);
+  log("parseYMD parts", { Y, M, D });
+  const result = new Date(Y, M - 1, D);
+  log("parseYMD result", { result: result.toISOString() });
+  return result;
 }
 function isWeekday(d) {
   const day = d.getDay(); // 0=вс, 6=сб
-  return day >= 1 && day <= 5;
+  const result = day >= 1 && day <= 5;
+  log("isWeekday evaluated", { date: d.toISOString(), day, result });
+  return result;
 }
 function sameDay(a, b) {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+  const result = a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+  log("sameDay compared", { a: a.toISOString(), b: b.toISOString(), result });
+  return result;
 }
 
 function checkTable(table, cfg) {
+  log("checkTable invoked", { cfg });
   // Собираем список дат из заголовка таблицы
   const theadDates = Array.from(table.querySelectorAll("thead th.period")).map(th => th.textContent.trim());
-  if (!theadDates.length) throw new Error("Заголовки с датами не найдены");
+  log("Table header dates", { theadDates });
+  if (!theadDates.length) {
+    log("No header dates found", { error: "missing_dates" });
+    throw new Error("Заголовки с датами не найдены");
+  }
 
   // Тело: ищем строку с суммами по дням
   const totalRow = table.querySelector("tbody tr.total");
-  if (!totalRow) throw new Error("Строка 'Общее время' не найдена");
+  log("Total row located", { exists: Boolean(totalRow) });
+  if (!totalRow) {
+    throw new Error("Строка 'Общее время' не найдена");
+  }
 
   // В totalRow: первый <td> — текст "Общее время", затем по одному <td.hours> на каждую дату, затем общий итог
   const dayCells = Array.from(totalRow.querySelectorAll("td.hours")); // включает и последний общий итог
-  const perDayCells = dayCells.slice(0, theadDates.length); // ровно столько, сколько заголовков-дней
+  const perDayCells = dayCells.slice(0, theadDates.length); // ровно столько, сколько аголовков-дней
+  log("Collected cells", { totalCells: dayCells.length, perDay: perDayCells.length });
 
   // Определяем текущую дату без учёта времени
   const today = new Date();
   today.setHours(0,0,0,0);
+  log("Normalized today", { today: today.toISOString() });
 
   const missingDays = [];
   let todayFound = false;
@@ -102,29 +145,42 @@ function checkTable(table, cfg) {
     const ymd = theadDates[i];
     const d = parseYMD(ymd);
     const isToday = sameDay(d, today);
-    if (d > today) return;
-    if (!isWeekday(d)) return;
+    log("Processing day cell", { index: i, ymd, isToday });
+    if (d > today) {
+      log("Skipping future date", { ymd });
+      return;
+    }
+    if (!isWeekday(d)) {
+      log("Skipping non-weekday", { ymd });
+      return;
+    }
 
     // Приводим текст ячейки к числу часов
     const txt = (td.textContent || "").replace(/\s+/g, "").replace(",", ".").trim(); // например "8.00"
+    log("Raw cell text", { ymd, txt });
     const parsed = txt ? parseFloat(txt) : 0;
     const hours = isFinite(parsed) ? parsed : 0;
     const ok = hours >= cfg.minHoursPerDay; // допускаем >= 8.00
+    log("Parsed cell", { ymd, parsed, hours, ok });
 
     if (isToday) {
       todayFound = true;
       todayHours = hours;
+      log("Updated today hours", { hours });
     } else if (!ok) {
       missingDays.push({ date: ymd, hours });
+      log("Recorded missing day", { ymd, hours });
     }
 
     if (cfg.highlight) {
       // Подсвечиваем ячейку в зависимости от выполнения нормы
       td.style.outline = `2px solid ${ok ? "#2e7d32" : "#d32f2f"}`;
       td.title = `${ok ? "OK" : "Недобор"}: ${hours.toFixed(2)} ч`;
+      log("Applied highlight", { ymd, ok, outline: td.style.outline, title: td.title });
     }
   });
 
-  return { missingDays, hoursToday: todayFound ? todayHours : 0, todayFound };
+  const summary = { missingDays, hoursToday: todayFound ? todayHours : 0, todayFound };
+  log("checkTable summary", summary);
+  return summary;
 }
-


### PR DESCRIPTION
## Summary
- add a reusable logging helper and instrument all background script operations with detailed console output
- add comprehensive console logging to the content script to trace table parsing and messaging flow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e79cc29fd48329829d17e294cbda7a