### PR TITLE
Handle default hours in background for errors

### DIFF
--- a/content.js
+++ b/content.js
@@ -34,9 +34,6 @@ log("Content script injected", { url: location.href, injectedAt: new Date().toIS
     chrome.runtime.sendMessage({
       type: "RM8H_RESULT",
       payload: {
-        missingDays: [],
-        hoursToday: 0,
-        todayFound: false,
         error: message,
         url: location.href,
         checkedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- move default hours fallback logic into the background script so it can react to availability failures
- simplify the content script error payload to let the background apply default hours consistently

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68f1e09e98f883299034302c2b869d9d