### PR TITLE
Добавить флаг учёта остатка текущего часа в бейдже

### DIFF
--- a/background.js
+++ b/background.js
@@ -362,24 +362,27 @@ function calculateExpectedHours(date, settings) {
   const end = parseTime(settings.workEnd);
   if (start == null || end == null || end <= start || current <= start) return 0;
 
-  // Текущий незавершённый час не учитываем в ожидаемом значении.
+  const includeCurrentHourRemainder = Boolean(settings.includeCurrentHourRemainder);
   const cappedCurrent = Math.min(current, end);
-  const completedHourBoundary = Math.floor(cappedCurrent / 60) * 60;
-  if (completedHourBoundary <= start) return 0;
+  const calculationBoundary = includeCurrentHourRemainder
+    ? cappedCurrent
+    : Math.floor(cappedCurrent / 60) * 60;
+  if (calculationBoundary <= start) return 0;
 
-  const workIntersection = Math.max(0, completedHourBoundary - start);
+  const workIntersection = Math.max(0, calculationBoundary - start);
   const lunchStart = parseTime(settings.lunchStart);
   const lunchDuration = settings.lunchDurationMinutes;
   const lunchEnd = lunchStart != null ? lunchStart + lunchDuration : null;
   const lunchIntersection = lunchStart != null && lunchEnd != null
-    ? Math.max(0, Math.min(completedHourBoundary, lunchEnd, end) - Math.max(start, lunchStart))
+    ? Math.max(0, Math.min(calculationBoundary, lunchEnd, end) - Math.max(start, lunchStart))
     : 0;
 
   const expected = Math.max(0, (workIntersection - lunchIntersection) / 60);
   log("Expected hours details", {
     current,
     cappedCurrent,
-    completedHourBoundary,
+    includeCurrentHourRemainder,
+    calculationBoundary,
     workIntersection,
     lunchIntersection,
     expected

--- a/options.html
+++ b/options.html
@@ -47,6 +47,7 @@
       <input id="lunchStart" type="time" />
       <label for="lunchDurationMinutes">Длительность обеда (минут)</label>
       <input id="lunchDurationMinutes" type="number" step="5" min="0" />
+      <label><input id="includeCurrentHourRemainder" type="checkbox" /> Учитывать оставшееся время текущего часа в бейдже</label>
       <label>Рабочие дни</label>
       <div class="weekdays">
         <label><input type="checkbox" name="workingDays" value="1" /> Пн</label>

--- a/options.js
+++ b/options.js
@@ -11,6 +11,7 @@ const els = {
   workEnd: document.getElementById("workEnd"),
   lunchStart: document.getElementById("lunchStart"),
   lunchDurationMinutes: document.getElementById("lunchDurationMinutes"),
+  includeCurrentHourRemainder: document.getElementById("includeCurrentHourRemainder"),
   workingDays: Array.from(document.querySelectorAll("input[name='workingDays']")),
   excludedRangesList: document.getElementById("excludedRangesList"),
   excludeFrom: document.getElementById("excludeFrom"),
@@ -32,6 +33,7 @@ async function load() {
   els.workEnd.value = normalized.workEnd;
   els.lunchStart.value = normalized.lunchStart;
   els.lunchDurationMinutes.value = normalized.lunchDurationMinutes;
+  els.includeCurrentHourRemainder.checked = normalized.includeCurrentHourRemainder;
 
   els.workingDays.forEach(cb => {
     cb.checked = normalized.workingDays.includes(Number(cb.value));
@@ -98,6 +100,7 @@ async function save() {
     workEnd: els.workEnd.value,
     lunchStart: els.lunchStart.value,
     lunchDurationMinutes: els.lunchDurationMinutes.value,
+    includeCurrentHourRemainder: !!els.includeCurrentHourRemainder.checked,
     workingDays,
     excludedDateRanges
   });

--- a/shared.js
+++ b/shared.js
@@ -13,6 +13,7 @@
     workEnd: "18:00",
     lunchStart: "13:00",
     lunchDurationMinutes: 60,
+    includeCurrentHourRemainder: false,
     workingDays: [1, 2, 3, 4, 5],
     excludedDateRanges: []
   };
@@ -129,6 +130,10 @@
       workEnd: normalizeTime(source.workEnd, DEFAULT_SETTINGS.workEnd),
       lunchStart: normalizeTime(source.lunchStart, DEFAULT_SETTINGS.lunchStart),
       lunchDurationMinutes: normalizeLunchDurationMinutes(source.lunchDurationMinutes),
+      includeCurrentHourRemainder: normalizeBoolean(
+        source.includeCurrentHourRemainder,
+        DEFAULT_SETTINGS.includeCurrentHourRemainder
+      ),
       workingDays: normalizeWorkingDays(source.workingDays),
       excludedDateRanges: normalizeExcludedDateRanges(source.excludedDateRanges)
     };


### PR DESCRIPTION
### Motivation
- Сейчас при запросе в начале часа незавершённый час не учитывается, из‑за чего бейдж может оставаться пустым до следующего часа; нужно дать возможность учитывать дробную часть текущего часа в расчёте дефицита.

### Description
- Добавлен новый флаг настроек `includeCurrentHourRemainder` (по умолчанию `false`) и его нормализация в `shared.js`.
- В UI (файл `options.html`) добавлен чекбокс «Учитывать оставшееся время текущего часа в бейдже» и подключение загрузки/сохранения флага в `options.js`.
- Обновлён алгоритм расчёта ожидаемых часов в `background.js` (`calculateExpectedHours`), который при включённом флаге использует текущую минуту как границу расчёта, а при выключенном — старое поведение (учёт только полностью завершённых часов).
- Форматирование текста бейджа по прежнему делегируется `formatHours`, который округляет/обрезает до максимум двух знаков после запятой.

### Testing
- Выполнена статическая проверка синтаксиса: `node --check background.js && node --check options.js && node --check shared.js` — успешно.
- Прогон тестового Node-скрипта, который загружает `shared.js` и `background.js`, выполняет несколько сценариев для `calculateExpectedHours` и проверяет `formatHours`, запущен вручную в VM — все проверки прошли успешно.
- Сделан локальный рендер страницы опций через `python -m http.server` и снят скриншот страницы с новым чекбоксом с помощью Playwright — визуальная проверка UI прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27f7930548329bf1dcbacacaf067f)