### PR TITLE
Count in-progress hour as full in badge calculation

### DIFF
--- a/background.js
+++ b/background.js
@@ -360,12 +360,14 @@ function calculateExpectedHours(date, settings) {
   const current = date.getHours() * 60 + date.getMinutes();
   const start = parseTime(settings.workStart);
   const end = parseTime(settings.workEnd);
-  if (start == null || end == null || end <= start || current <= start) return 0;
+  if (start == null || end == null || end <= start || current < start) return 0;
 
   const includeCurrentHourRemainder = Boolean(settings.includeCurrentHourRemainder);
   const cappedCurrent = Math.min(current, end);
   const calculationBoundary = includeCurrentHourRemainder
-    ? cappedCurrent
+    // При включённой опции незавершённый рабочий час учитываем целиком
+    ? Math.min(end, Math.floor(cappedCurrent / 60) * 60 + 60)
+    // Иначе учитываем только полностью завершённые часы
     : Math.floor(cappedCurrent / 60) * 60;
   if (calculationBoundary <= start) return 0;
 


### PR DESCRIPTION
### Motivation
- Бейдж с недобором часов должен учитывать незавершённый текущий рабочий час целиком, когда включена опция `includeCurrentHourRemainder`, чтобы поведение соответствовало ожиданиям (например, в 09:00 — показать 1 час). 
- Коррекция нужна также для граничного случая старта смены, чтобы проверка ровно в `workStart` корректно учитывала первый час при включённой опции.

### Description
- В `calculateExpectedHours` изменено вычисление `calculationBoundary`: при `includeCurrentHourRemainder` теперь округляем текущий незавершённый час вверх до конца часа и капаем по `workEnd` (`Math.min(end, Math.floor(cappedCurrent / 60) * 60 + 60)`), иначе сохраняется прежнее поведение (учёт только завершённых часов). 
- Исправлено условие раннего выхода с `current <= start` на `current < start`, чтобы проверка ровно в `workStart` не возвращала 0 и позволяла показать первый час при включённой опции. 
- Логика вычитания обеденного времени оставлена без изменений и применяется к новому `calculationBoundary` для корректного результата.

### Testing
- Выполнена статическая проверка синтаксиса с помощью `node --check background.js`, тест пройден успешно.
- Изменение внесено в файл `background.js` и закоммичено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf7f236a788329afc614977b9bdc59)